### PR TITLE
prevent two target get is-active class

### DIFF
--- a/js/components/stalker.js
+++ b/js/components/stalker.js
@@ -171,7 +171,7 @@ var Stalker = Toolkit.Stalker = Component.extend({
 
             var offset = offsets[index],
                 top = offset.top - threshold,
-                bot = offset.top + marker.height() + threshold;
+                bot = offset.top + marker.height() - threshold;
 
             // Scroll is within the marker
             if (


### PR DESCRIPTION
if threshold added to top and bottom, it may has two is-active targets at once.
but I think in most of case, only single item needs to be marked while scrolling.
please add this commit if you think my idea is ok.