### PR TITLE
Fix table formatting

### DIFF
--- a/docs/en/support/comparison.md
+++ b/docs/en/support/comparison.md
@@ -681,7 +681,6 @@ The following plugins are found within Semantic UI that have not been mentioned 
             <td class="is-success">&check;</td>
             <td class="is-success">&check;</td>
         </tr>
-
         <tr class="table-divider">
             <td colspan="5">Packagers</td>
         </tr>
@@ -713,7 +712,6 @@ The following plugins are found within Semantic UI that have not been mentioned 
             <td class="is-success">&check;</td>
             <td class="is-error"></td>
         </tr>
-
         <tr class="table-divider">
             <td colspan="5">Functionality</td>
         </tr>


### PR DESCRIPTION
extra line breaks were creating a code block
current broken state is evident at http://titon.io/en/toolkit/2.1.6/support/comparison#features